### PR TITLE
Whitelist commands that are allowed to use the new storage path

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -42,3 +42,25 @@ to
 $app = new Noprotocol\EnvOmroep\LaravelApplication(
 ```
 (If you're using a custom Application class, update superclass to Noprotocol\EnvOmroep\LaravelApplication)
+
+## Creating folders
+
+The omroep server does not like when you create folders via FTP or SSH on the data disk. The permissions get all wrong and it is a mess to fix.
+You can use this script to create the folders via the webserver user.
+
+Place this script in the public folder and remove it after using:
+
+```
+<?php
+    header('Content-Type: text/plain');
+    ini_set('display_errors', true);
+
+    echo "Preparing data folder\n";
+    require(__DIR__ . '/../vendor/autoload.php');
+
+    $dataFolder = new Noprotocol\EnvOmroep\DataFolder();
+    $dataFolder->createLaravelFolders();
+    $dataFolder->mkdir('uploads');
+
+    echo "completed\n";
+```

--- a/Readme.md
+++ b/Readme.md
@@ -22,9 +22,15 @@ Add **noprotocol/env-omroep** as a composer dependancy:
 ## Configuration
 
 Add `DATA_PATH` to your `.env`
- 
+
 ```
 DATA_PATH=/e/ap/$domain/data
+```
+
+Add `DATA_STORAGE_COMMANDS` to your `.env` if you need certain commands to use the new storage path
+
+```
+DATA_STORAGE_COMMANDS=site:canlog,site:another
 ```
 
 In /bootstap/app.php change:

--- a/Readme.md
+++ b/Readme.md
@@ -52,15 +52,16 @@ Place this script in the public folder and remove it after using:
 
 ```
 <?php
-    header('Content-Type: text/plain');
-    ini_set('display_errors', true);
 
-    echo "Preparing data folder\n";
-    require(__DIR__ . '/../vendor/autoload.php');
+header('Content-Type: text/plain');
+ini_set('display_errors', true);
 
-    $dataFolder = new Noprotocol\EnvOmroep\DataFolder();
-    $dataFolder->createLaravelFolders();
-    $dataFolder->mkdir('uploads');
+echo "Preparing data folder\n";
+require(__DIR__ . '/../vendor/autoload.php');
 
-    echo "completed\n";
+$dataFolder = new Noprotocol\EnvOmroep\DataFolder();
+$dataFolder->createLaravelFolders();
+$dataFolder->mkdir('uploads');
+
+echo "completed\n";
 ```

--- a/src/LaravelApplication.php
+++ b/src/LaravelApplication.php
@@ -17,7 +17,7 @@ class LaravelApplication extends Application {
             $dotenv = new \Dotenv\Dotenv($this->environmentPath(), $this->environmentFile());
             $dotenv->load();
         }
-        if (env('DATA_PATH') && !$this->runningInConsole()) {
+        if (env('DATA_PATH') && $this->needsStorage()) {
             $this->useStoragePath(env('DATA_PATH').'/storage');
         }
     }
@@ -27,6 +27,17 @@ class LaravelApplication extends Application {
             return env('DATA_PATH') . '/bootstrap/services.php';
         }
         return parent::getCachedServicesPath();
+    }
+
+    private function needsStorage() {
+        if($this->runningInConsole()){
+            if(env('DATA_STORAGE_COMMANDS') && isset($_SERVER['argv'][1])){
+                $commandsThatNeedStorage = explode(',' , env('DATA_STORAGE_COMMANDS'));
+                return in_array($_SERVER['argv'][1], $commandsThatNeedStorage);
+            }
+            return false;
+        }
+        return true;
     }
 
 }


### PR DESCRIPTION
Added DATA_STORAGE_COMMANDS env variable to whitelist commands that are allowed use the new storage path.

Also the docs are updated with this change and with the folder create script.